### PR TITLE
Use source to run hook commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages
 
 setup(
     name="yaghm",
-    version="0.1.4",
+    version="0.1.5",
     description="Minimal git hook manager for the command line.",
     long_description=Path("README.md").read_text(),
     long_description_content_type="text/markdown",

--- a/src/yaghm/templates/wrapper.jinja2
+++ b/src/yaghm/templates/wrapper.jinja2
@@ -8,4 +8,4 @@ stage: Git hook stage, eg. pre-commit
 
 set -e
 
-/usr/bin/env sh .git/hooks/{{ stage }}.yaghm.commands
+source .git/hooks/{{ stage }}.yaghm.commands


### PR DESCRIPTION
Running in a subshell subverts the wrapper's `set -e`, and causes some funny business if one hook exits with 1 but then another one after it exits with 0.
