### PR TITLE
Add hook def to repo + example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ pre-commit:
   - enable: black --check .
     install: pip install black
     update: pip install -U black
-  - enable: require_version_bump
-    update: pip install -U black
+  - enable: require_version_bump master setup.py
+    update: pip install -U metovhooks
 
 post-commit:
   - ...

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can use `yaghm -h` to see general help. There are three main subcommands (wh
 
 When using `enable` and `disable`, if you pass `--dryrun` no files will actually be written.
 
-You can also run custom hook command (eg. update) with `yaghm update`. If any hooks in your config [specify the command](doc/config.md), it will be executed.
+You can also run custom hook commands (e.g. update) with `yaghm update`. If any hooks in your config [specify the command](doc/config.md), it will be executed.
 
 ## Install
 Install with `pip install yaghm`

--- a/doc/config.md
+++ b/doc/config.md
@@ -5,3 +5,5 @@ A yaghm config is a YAML dictionary where keys are names of git hooks (eg. `pre-
 * Dictionaries must have an `enable` key which is where you provide the hook command. They can also have additional key-values where the key is the name of the command (eg. `install`) and the value is the corresponding command.
 
 By specifying an `install` or `update` command for several hooks, for example, you can easily install or update all your hooks by running `yaghm install` or `yaghm update`.
+
+You can also check out the [`yaghm.yaml`](../yaghm.yaml) file in this repository. Since I use yaghm to manage my hooks for this repo, this doubles as a real-world example.

--- a/src/yaghm/enable.py
+++ b/src/yaghm/enable.py
@@ -10,7 +10,7 @@ Usage:
 
 Options:
     --conf PATH  Use given config instead of yaghm.yaml in repo root
-    --dryrun  Only echo what would have been done, don't actually do it.
+    --dryrun  Only echo what would have been done, don't actually do it
     -y  Non interactive mode, assume safe defaults instead of prompting user
 """
 import subprocess

--- a/yaghm.yaml
+++ b/yaghm.yaml
@@ -1,0 +1,11 @@
+# Hooks for this repository; but also an example
+# To activate, run in the repo root: yaghm enable .
+
+pre-commit:
+  # The value of enable is the command that will be executed by the hook
+  - enable: require_version_bump master setup.py
+    # Additional keys like install are so that we can do yaghm install .
+    install: pip install metovhooks
+
+  # If we're only specifying the command, we can omit the enable
+  - black --check .


### PR DESCRIPTION
This fixes the example in #5, and also adds a hook definition to the repo itself. This definition serves as an additional example.
