### PR TITLE
Add support for custom commands

### DIFF
--- a/doc/technical.md
+++ b/doc/technical.md
@@ -1,4 +1,2 @@
 # How it works
-Yaghm puts a simple wrapper script at the hook entrypoint (eg. `.git/hooks/pre-commit`) and a list of commands with matching name 
-
-Yaghm operates based on a config file, which is treated as a wishlist of what hooks *should* be enabled in the target repo. These are composed into a list of commands (eg. `.git/hooks/pre-commit.yaghm.commands`). The actual hook entrypoint (eg. `.git/hooks/pre-commit`) is a simple shell script that calls each command in the list. This shell script will be triggered by git as per the normal hooks behavior.
+Yaghm operates based on a config file, which is treated as a wishlist of what hooks *should* be enabled in the target repo. These are composed into a list of commands (eg. `.git/hooks/pre-commit.yaghm.commands`). The actual hook entrypoint (eg. `.git/hooks/pre-commit`) is a Python script that invokes each command in the list. This script will be triggered by git as per the normal hooks behavior.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages
 
 setup(
     name="yaghm",
-    version="0.2.0",
+    version="0.2.1",
     description="Minimal git hook manager for the command line.",
     long_description=Path("README.md").read_text(),
     long_description_content_type="text/markdown",

--- a/src/yaghm/custom_command.py
+++ b/src/yaghm/custom_command.py
@@ -14,13 +14,7 @@ from pathlib import Path
 from docopt import docopt
 
 from yaghm import log
-from yaghm.lib import (
-    hooks_path,
-    VALID_HOOKS,
-    render_wrapper,
-    commands_path,
-    load_config,
-)
+from yaghm.lib import VALID_HOOKS, load_config
 
 
 def main(command_name, argv):

--- a/src/yaghm/custom_command.py
+++ b/src/yaghm/custom_command.py
@@ -1,0 +1,59 @@
+"""
+Run custom command (if defined) for each hook.
+
+Usage:
+    CMDNAME [options]
+
+Options:
+    --conf PATH  Use given config instead of yaghm.yaml in current working directory
+    --dryrun  Only echo what would have been done, don't actually do it
+"""
+import subprocess
+from pathlib import Path
+
+from docopt import docopt
+
+from yaghm import log
+from yaghm.lib import (
+    hooks_path,
+    VALID_HOOKS,
+    render_wrapper,
+    commands_path,
+    load_config,
+)
+
+
+def main(command_name, argv):
+    args = docopt(__doc__, argv=argv)
+
+    log.debug(f"Arguments:\n{args}")
+
+    pconf = Path(args["--conf"] or "yaghm.yaml")
+    config = load_config(pconf)
+
+    for hook in VALID_HOOKS:
+        if hook not in config:
+            log.debug(f"No {hook} hook defined, skipping.")
+            continue
+
+        cmds = config[hook]
+        for c in cmds:
+            if not isinstance(c, dict):
+                log.info(f"No {command_name} defined for: {c}")
+                continue
+
+            if command_name not in c:
+                log.info(f"No {command_name} defined for: {c['enable']}")
+                continue
+
+            cmd = c[command_name]
+            if not args["--dryrun"]:
+                res = subprocess.run(cmd, shell=True).returncode
+            else:
+                print(f"Pretending to run: {cmd}")
+                res = 0
+
+            if res == 0:
+                log.info(f"Command successful: {cmd}")
+            else:
+                log.error(f"Command failed: {cmd}")

--- a/src/yaghm/enable.py
+++ b/src/yaghm/enable.py
@@ -18,7 +18,6 @@ from pathlib import Path
 
 import questionary
 from docopt import docopt
-from ruamel.yaml import YAML
 
 from yaghm import log
 from yaghm.lib import (
@@ -28,6 +27,7 @@ from yaghm.lib import (
     render_wrapper,
     backup_path,
     commands_path,
+    load_config,
 )
 
 
@@ -41,21 +41,16 @@ def main(argv):
 
     conf_override = args["--conf"]
     pconf = Path(conf_override) if conf_override else prepo / "yaghm.yaml"
-    if not pconf.exists():
-        log.critical(f"File does not exist: {pconf}")
-        exit(1)
+    config = load_config(pconf)
 
     dryrun = bool(args["--dryrun"])
     noask = bool(args["-y"])
 
-    enable_hooks(prepo, pconf, dryrun, noask)
+    enable_hooks(prepo, config, dryrun, noask)
 
 
-def enable_hooks(prepo, pconf, dryrun, noask):
-    yaml = YAML()
-    config = yaml.load(pconf.open())
+def enable_hooks(prepo, config, dryrun, noask):
     hooks = collect_hook_commands(config)
-
     for stage, hooks in hooks.items():
         make_wrapper(prepo, stage, dryrun)
         make_commands(prepo, stage, hooks, dryrun)

--- a/src/yaghm/lib.py
+++ b/src/yaghm/lib.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 
 from jinja2 import Environment, PackageLoader
+from ruamel.yaml import YAML
 
 from yaghm import log
 
@@ -50,3 +51,13 @@ def backup_path(wrapper_path):
 
 def commands_path(phooks, hook):
     return Path(phooks) / f"{hook}.yaghm.commands"
+
+
+def load_config(config_path: Path):
+    if not config_path.exists():
+        log.critical(f"File does not exist: {config_path}")
+        exit(1)
+
+    yaml = YAML()
+    config = yaml.load(config_path.open())
+    return config

--- a/src/yaghm/main.py
+++ b/src/yaghm/main.py
@@ -6,6 +6,7 @@ Usage:
     yaghm [--log LEVEL] enable [<args>...]
     yaghm [--log LEVEL] list [<args>...]
     yaghm [--log LEVEL] disable [<args>...]
+    yaghm [--log LEVEL] CMDNAME [<args>...]
 
 Options:
     --log LEVEL  Minimum level of logs to print [default: INFO]
@@ -14,7 +15,7 @@ import logging
 
 from docopt import docopt
 
-from yaghm import log, enable, disable, list_hooks
+from yaghm import log, enable, disable, list_hooks, custom_command
 
 
 def main():
@@ -32,6 +33,5 @@ def main():
         disable.main(argv)
     elif args["list"]:
         list_hooks.main(argv)
-        # TODO: Implement custom commands
     else:
-        log.critical("Should not have been allowed to reach this point by docopt.")
+        custom_command.main(args["CMDNAME"], argv)

--- a/yaghm.yaml
+++ b/yaghm.yaml
@@ -3,11 +3,14 @@
 
 pre-commit:
   # The value of enable is the command that will be executed by the hook
-  - enable: require_version_bump master setup.py
+  - enable: black --check .
     # Additional keys like install are so that we can do: yaghm install .
+    install: pip install black
+
+  - enable: protect_branch master
     install: pip install metovhooks
     # Custom commands: This one will be executed by: yaghm update
     update: pip install -U metovhooks
 
   # If we're only specifying the command, we can omit the enable
-  - black --check .
+  - require_version_bump master setup.py

--- a/yaghm.yaml
+++ b/yaghm.yaml
@@ -4,8 +4,10 @@
 pre-commit:
   # The value of enable is the command that will be executed by the hook
   - enable: require_version_bump master setup.py
-    # Additional keys like install are so that we can do yaghm install .
+    # Additional keys like install are so that we can do: yaghm install .
     install: pip install metovhooks
+    # Custom commands: This one will be executed by: yaghm update
+    update: pip install -U metovhooks
 
   # If we're only specifying the command, we can omit the enable
   - black --check .


### PR DESCRIPTION
Custom commands allow you to define an arbitrary command in the yaghm config, such as `update`. The custom command can then be invoked with `yaghm update`, which will run whatever is in `update` of each hook command that has `update` defined.
